### PR TITLE
bounty is raised if its to low before being send to the dlt

### DIFF
--- a/src/services/add-job-service.ts
+++ b/src/services/add-job-service.ts
@@ -53,23 +53,14 @@ export default async function addAllJobs(packageData: PackageData) {
                 bounty: BigInt(bounty),
             };
 
-            const encoded = await encodeJob(data);
-
-            const keys = await getKeys();
-
-            const signature = await signMessage(encoded, keys.id);
-
-            const job = {
-                data,
-                signature,
-            };
+            const job = await encodeAndSign(data);
 
             const module = getModule('coda:AddJob');
             const transaction = {
                 moduleID: module.moduleID,
                 assetID: module.assetID,
                 fee: BigInt(10000000),
-                asset: job as unknown as Record<string, unknown>,
+                asset: job,
             };
 
             addToHeap({
@@ -82,5 +73,15 @@ export default async function addAllJobs(packageData: PackageData) {
     }
 }
 
+export async function encodeAndSign(data: CodaJob): Promise<Record<string, any>>
+{
+    const encoded = await encodeJob(data);
+    const keys = await getKeys();
+    const signature = await signMessage(encoded, keys.id);
+    return {
+        data,
+        signature,
+    };
+}
 /* This program has been developed by students from the bachelor Computer Science at Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences) */

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -3,8 +3,10 @@ import Emitter from 'node:events';
 import { QueueTransaction } from '../types';
 import {
     getAccount,
-    getClient, getMinFee, getPassphrase, runTransaction,
+    getClient, getMinFee, getPassphrase, runTransaction, getMinimumBounty
 } from './dlt-service';
+import { encodeAndSign } from './add-job-service'
+import {CodaJob} from '../types'
 
 const heap = new Heap<QueueTransaction>(comparator);
 const emitter = new Emitter();
@@ -44,14 +46,23 @@ async function consumeFromHeap(client) {
     console.log(`Running transaction: ${queueTransaction.name}`);
 
     try {
-        // @ts-ignore
-        const bounty = queueTransaction.transaction.asset?.bounty;
+        const data = queueTransaction.transaction.asset.data;
+        if (data)
+            var bounty = (data as CodaJob).bounty;
         const { slingers } = await getAccount();
+        const minimumBounty = BigInt(await getMinimumBounty());
 
         if (bounty > slingers) {
             console.log('Not enough tokens to run this transaction, skipping...');
             await consumeFromHeap(client);
             return;
+        }
+
+        if (bounty < minimumBounty){
+            console.log('Bounty to low, setting value to minimumBounty');
+            let data = queueTransaction.transaction.asset.data;
+            (data as CodaJob).bounty = BigInt(minimumBounty);
+            queueTransaction.transaction.asset = await encodeAndSign(data as CodaJob);
         }
 
         const minFee = await getMinFee(queueTransaction.transaction);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,14 @@ export interface QueueTransaction {
     name?: string,
     priority: number,
     created_at: number,
-    transaction: Record<string, unknown>
+    transaction: QTransaction
+}
+
+export interface QTransaction {
+    moduleID: number,
+    assetID: number,
+    fee: BigInt,
+    asset: Record<string, unknown>
 }
 
 export interface Miner {


### PR DESCRIPTION
 Closes #17  

Added a check to see if the bounty is lower than the minimum required bounty, if that is the case the bounty is increased before sending over the transaction to the the ledger. This was caused by the minimum bounty changing between it being queued and actually being send of to the ledger, because for example more facts having been submitted.