### PR TITLE
added limit to how many times the spider jobs get retried

### DIFF
--- a/src/services/dlt-service.ts
+++ b/src/services/dlt-service.ts
@@ -3,7 +3,7 @@ import { RegisteredModule } from '@liskhq/lisk-api-client/dist-node/types';
 import { APIClient } from '@liskhq/lisk-api-client';
 import fs from 'fs';
 import {
-    CodaJob, Job, RandomJobResult,
+    CodaJob, Job, RandomJobResult, PackageData
 } from '../types';
 import 'dotenv/config';
 import { getKeys } from '../keys';
@@ -59,7 +59,7 @@ export async function getGitHubLink() {
     return storage.github_link;
 }
 
-export async function getJobs(): Promise<Job[]> {
+export async function getJobs(): Promise<CodaJob[]> {
     const client = await getClient();
     return client.invoke('coda:getJobs');
 }
@@ -73,7 +73,39 @@ export async function getRandomJob(): Promise<RandomJobResult> {
     });
 }
 
-export async function getTrustFacts(packageName: string): Promise<unknown> {
+export async function getAllUnfinishedJobs(): Promise<CodaJob[]> {
+    const { id } = await getKeys();
+    let allJobs = await getJobs();
+    let unfinished = await Promise.all(allJobs.map(async job => {
+        let trustFacts = (await getTrustFacts(job.package)).facts;
+        if (trustFacts === undefined) return true;
+        return !trustFacts.some(fact => fact.account.uid === id && fact.jobID === job.jobID);
+    }))
+    let unfinishedJobs = allJobs.filter((_, i) => unfinished[i]);
+    return unfinishedJobs;
+}
+
+export async function getJobDetails(job: CodaJob): Promise<RandomJobResult> {
+    let packageData = await getPackageData(job.package);
+
+    return {
+        package: job.package,
+        version: job.version,
+        fact: job.fact,
+        date: job.date,
+        jobID: job.jobID.toString(),
+        bounty: job.bounty.toString(),
+        account: {
+            uid: job.account.uid,
+        },
+        packageName: packageData.packageName,
+        packagePlatform: packageData.packagePlatform,
+        packageOwner: packageData.packageOwner,
+        packageReleases: packageData.packageReleases,
+    }
+}
+
+export async function getTrustFacts(packageName: string): Promise<any> {
     const client = await getClient();
     return client.invoke('trustfacts:getPackageFacts', {
         packageName,
@@ -84,7 +116,7 @@ export function getModule(name: string) {
     return registeredTransactions[name];
 }
 
-export async function getPackageData(packageName): Promise<string> {
+export async function getPackageData(packageName): Promise<PackageData> {
     const client = await getClient();
     return client.invoke('packagedata:getPackageInfo', {
         packageName,

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -83,5 +83,15 @@ function comparator(a: QueueTransaction, b: QueueTransaction) {
     return (a.priority + sinceA) - (b.priority + sinceB);
 }
 
+export function isJobInHeap(jobID: number): boolean {
+    return heap.toArray().some((queueTransaction) => {
+        const data = queueTransaction.transaction.asset.data;
+        if (data){
+            return (data as CodaJob).jobID === jobID;
+        }
+        return false;
+    })
+}
+
 /* This program has been developed by students from the bachelor Computer Science at Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences) */

--- a/src/services/spider-service.ts
+++ b/src/services/spider-service.ts
@@ -10,6 +10,7 @@ import { addToHeap } from './queue-service';
 
 const SPIDER_ENDPOINT = 'http://spider:5000/';
 const emitter = new Emitter();
+emitter.on("info", (message) => console.log(`INFO:${message}`));
 const spider = axios.create({
     baseURL: SPIDER_ENDPOINT,
 });

--- a/src/services/spider-service.ts
+++ b/src/services/spider-service.ts
@@ -4,7 +4,7 @@ import Emitter from 'node:events';
 import {
     Job, RandomJobResult, SpiderJob, Tokens,
 } from '../types';
-import { encodeFact, getModule, getRandomJob } from './dlt-service';
+import { encodeFact, getModule, getRandomJob, getAllUnfinishedJobs, getJobDetails } from './dlt-service';
 import { getKeys, signMessage } from '../keys';
 import { addToHeap } from './queue-service';
 
@@ -13,6 +13,7 @@ const emitter = new Emitter();
 const spider = axios.create({
     baseURL: SPIDER_ENDPOINT,
 });
+const retryCount = 2; // How often a job should be retried before giving up
 
 export async function setTokens(tokens: Tokens): Promise<string> {
     const { data } = await spider.post('set_tokens', tokens);
@@ -63,37 +64,52 @@ let running = false;
 
 export async function startSpider() {
     running = true;
-    while (running) {
-        let job;
+    let jobCounts = {}; // the amount of times a job has failed
 
-        try {
-            job = await getRandomJob();
-            emitter.emit('info', `Got Spider job for package ${job.packageName} with fact ${job.fact}`);
-        } catch (e) {
-            console.log(e);
+    while (running) {
+        let jobs = await getAllUnfinishedJobs();
+
+        if (jobs.length === 0)
+        {
             emitter.emit('info', 'No Spider job available! Sleeping for 30 sec.');
             await sleep(30 * 1000);
             continue;
         }
 
-        emitter.emit('info', `Got Spider job for package ${job.packageName} with fact ${job.fact}`);
+        let filteredJobs = jobs.filter(job => !(job.jobID in jobCounts && jobCounts[job.jobID] >= retryCount))
+
+        if (filteredJobs.length === 0)
+        {
+            emitter.emit('info', 'All available spider jobs have been tried more than retry count already! Sleeping for 30 sec.');
+            await sleep(30 * 1000);
+            continue;
+        }
+
+        let job = await getJobDetails(filteredJobs[Math.floor(Math.random() * filteredJobs.length)]);
+
+        emitter.emit('info', `Got Spider job for package ${job.package} with fact ${job.fact}`);
 
         const spiderResult = await runJob(job);
+
 
         const dataPoint = spiderResult[job.fact];
 
         if (dataPoint === undefined || dataPoint === null) {
             emitter.emit('info', `The spider returned null for ${job.fact}! Finding a new job!`);
+            if (!(job.jobID in jobCounts))
+                jobCounts[job.jobID] = 1
+            else
+                jobCounts[job.jobID] += 1
             await sleep(5 * 1000);
             continue;
         }
 
-        emitter.emit('info', `The ${job.fact} for ${job.packageName} is ${dataPoint}`);
+        emitter.emit('info', `The ${job.fact} for ${job.package} is ${dataPoint}`);
 
         const keys = await getKeys();
 
         const data = {
-            jobID: job.jobID,
+            jobID: Number(job.jobID),
             factData: JSON.stringify(dataPoint),
         };
 

--- a/src/services/spider-service.ts
+++ b/src/services/spider-service.ts
@@ -6,7 +6,7 @@ import {
 } from '../types';
 import { encodeFact, getModule, getRandomJob, getAllUnfinishedJobs, getJobDetails } from './dlt-service';
 import { getKeys, signMessage } from '../keys';
-import { addToHeap } from './queue-service';
+import { addToHeap, isJobInHeap } from './queue-service';
 
 const SPIDER_ENDPOINT = 'http://spider:5000/';
 const emitter = new Emitter();
@@ -80,7 +80,9 @@ export async function startSpider() {
             continue;
         }
 
-        let filteredJobs = jobs.filter(job => !(job.jobID in jobCounts && jobCounts[job.jobID] >= retryCount))
+        let filteredJobs = jobs.filter(job =>
+            !(job.jobID in jobCounts && jobCounts[job.jobID] >= retryCount) &&
+            !(isJobInHeap(job.jobID)))
 
         if (filteredJobs.length === 0)
         {
@@ -134,7 +136,7 @@ export async function startSpider() {
             asset: trustFact as unknown as Record<string, unknown>,
         };
 
-        emitter.emit('info', 'Finished job, adding to dlt queue!');
+        emitter.emit('info', `Finished job ${job.jobID}, adding to dlt queue!`);
 
         addToHeap({
             transaction,

--- a/src/services/spider-service.ts
+++ b/src/services/spider-service.ts
@@ -94,15 +94,15 @@ export async function startSpider() {
 
         const spiderResult = await runJob(job);
 
+        if (!(job.jobID in jobCounts))
+            jobCounts[job.jobID] = 1
+        else
+            jobCounts[job.jobID] += 1
 
         const dataPoint = spiderResult[job.fact];
 
         if (dataPoint === undefined || dataPoint === null) {
             emitter.emit('info', `The spider returned null for ${job.fact}! Finding a new job!`);
-            if (!(job.jobID in jobCounts))
-                jobCounts[job.jobID] = 1
-            else
-                jobCounts[job.jobID] += 1
             await sleep(5 * 1000);
             continue;
         }

--- a/src/services/spider-service.ts
+++ b/src/services/spider-service.ts
@@ -4,7 +4,7 @@ import Emitter from 'node:events';
 import {
     Job, RandomJobResult, SpiderJob, Tokens,
 } from '../types';
-import { encodeFact, getModule, getRandomJob } from './dlt-service';
+import { encodeFact, getModule, getRandomJob, getAllUnfinishedJobs, getJobDetails } from './dlt-service';
 import { getKeys, signMessage } from '../keys';
 import { addToHeap } from './queue-service';
 
@@ -13,6 +13,7 @@ const emitter = new Emitter();
 const spider = axios.create({
     baseURL: SPIDER_ENDPOINT,
 });
+const retryCount = 2; // How often a job should be retried before giving up
 
 export async function setTokens(tokens: Tokens): Promise<string> {
     const { data } = await spider.post('set_tokens', tokens);
@@ -66,37 +67,52 @@ let running = false;
 
 export async function startSpider() {
     running = true;
-    while (running) {
-        let job;
+    let jobCounts = {}; // the amount of times a job has failed
 
-        try {
-            job = await getRandomJob();
-            emitter.emit('info', `Got Spider job for package ${job.packageName} with fact ${job.fact}`);
-        } catch (e) {
-            console.log(e);
+    while (running) {
+        let jobs = await getAllUnfinishedJobs();
+
+        if (jobs.length === 0)
+        {
             emitter.emit('info', 'No Spider job available! Sleeping for 30 sec.');
             await sleep(30 * 1000);
             continue;
         }
 
-        emitter.emit('info', `Got Spider job for package ${job.packageName} with fact ${job.fact}`);
+        let filteredJobs = jobs.filter(job => !(job.jobID in jobCounts && jobCounts[job.jobID] >= retryCount))
+
+        if (filteredJobs.length === 0)
+        {
+            emitter.emit('info', 'All available spider jobs have been tried more than retry count already! Sleeping for 30 sec.');
+            await sleep(30 * 1000);
+            continue;
+        }
+
+        let job = await getJobDetails(filteredJobs[Math.floor(Math.random() * filteredJobs.length)]);
+
+        emitter.emit('info', `Got Spider job for package ${job.package} with fact ${job.fact}`);
 
         const spiderResult = await runJob(job);
+
 
         const dataPoint = spiderResult[job.fact];
 
         if (dataPoint === undefined || dataPoint === null) {
             emitter.emit('info', `The spider returned null for ${job.fact}! Finding a new job!`);
+            if (!(job.jobID in jobCounts))
+                jobCounts[job.jobID] = 1
+            else
+                jobCounts[job.jobID] += 1
             await sleep(5 * 1000);
             continue;
         }
 
-        emitter.emit('info', `The ${job.fact} for ${job.packageName} is ${dataPoint}`);
+        emitter.emit('info', `The ${job.fact} for ${job.package} is ${dataPoint}`);
 
         const keys = await getKeys();
 
         const data = {
-            jobID: job.jobID,
+            jobID: Number(job.jobID),
             factData: JSON.stringify(dataPoint),
         };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,17 @@ export interface PackageData {
 }
 
 export interface CodaJob {
-    package: string,
-    version: string,
-    fact: string,
-    bounty: bigint,
+    package: string;
+    version: string;
+    fact: string;
+    date?: string;
+    jobID?: number;
+    bounty: bigint;
+    account?: AccountId;
+}
+
+export interface AccountId {
+    uid: string;
 }
 
 export interface RandomJobResult {


### PR DESCRIPTION
Instead of asking the ledger for a random job, cosy picks a random job out of the list of all jobs that haven't been tried more than a certain time and that aren't currently waiting to be uploaded to the ledger.